### PR TITLE
优化agent启动时异常提示信息

### DIFF
--- a/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/KafkaWriter.java
+++ b/apm-sniffer/apm-agent-core/src/main/java/org/apache/skywalking/apm/agent/core/logging/core/KafkaWriter.java
@@ -53,7 +53,7 @@ public class KafkaWriter implements IWriter {
 
                                 logService.flush();
                             } catch (Throwable t) {
-                                SystemOutWriter.INSTANCE.write(t.toString());
+                                SystemOutWriter.INSTANCE.write("skywalking-agent WARN: " + t.toString());
 
                                 for (String message : outputLogs) {
                                     SystemOutWriter.INSTANCE.write(message);

--- a/apm-sniffer/optional-reporter-plugins/kafka-logging-plugin/src/main/java/org/apache/skywalking/apm/agent/core/logging/kafka/KafkaLogService.java
+++ b/apm-sniffer/optional-reporter-plugins/kafka-logging-plugin/src/main/java/org/apache/skywalking/apm/agent/core/logging/kafka/KafkaLogService.java
@@ -25,6 +25,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.skywalking.apm.agent.core.boot.OverrideImplementor;
 import org.apache.skywalking.apm.agent.core.boot.ServiceManager;
+import org.apache.skywalking.apm.agent.core.logging.api.ILog;
+import org.apache.skywalking.apm.agent.core.logging.api.LogManager;
 import org.apache.skywalking.apm.agent.core.logging.core.LogService;
 import org.apache.skywalking.apm.agent.core.logging.core.SystemOutWriter;
 
@@ -32,6 +34,8 @@ import java.nio.charset.StandardCharsets;
 
 @OverrideImplementor(LogService.class)
 public class KafkaLogService extends LogService {
+
+    private static final ILog logger = LogManager.getLogger(KafkaLogService.class);
 
     private KafkaProducer<Bytes, Bytes> producer;
     private String topic;
@@ -69,7 +73,11 @@ public class KafkaLogService extends LogService {
     }
 
     @Override
-    public void flush() {
+    public void flush() throws NullPointerException {
+        if (producer == null) {
+            logger.warn("KafkaProducer is creating");
+            return;
+        }
         producer.flush();
     }
 }


### PR DESCRIPTION
应用启动时发送日志的kafka客户端初始化比较晚，会报空异常让人误解，优化提示信息